### PR TITLE
fix(avatar): 外置登录头像加载埋点 Serilog 日志，修复 CharacterManagementPage 回退路径

### DIFF
--- a/XianYuLauncher/Services/DialogService.cs
+++ b/XianYuLauncher/Services/DialogService.cs
@@ -577,8 +577,9 @@ public class DialogService : IDialogService
             items.Add(item);
         }
 
-        // 2. 启动异步加载头像任务
+        // 2. 启动异步加载头像任务（对话框关闭时取消，避免后台继续请求）
         Log.Information("[Avatar.DialogService] 外置角色选择对话框，AuthServer: {AuthServer}, 角色数: {Count}", authServer ?? "(null)", profiles.Count);
+        var avatarLoadCts = new CancellationTokenSource();
         _ = Task.Run(async () => 
         {
             if (string.IsNullOrEmpty(authServer))
@@ -588,6 +589,7 @@ public class DialogService : IDialogService
             }
             foreach (var item in items)
             {
+                avatarLoadCts.Token.ThrowIfCancellationRequested();
                 try
                 {
                     var server = authServer;
@@ -595,7 +597,7 @@ public class DialogService : IDialogService
                     var sessionUrl = $"{server}sessionserver/session/minecraft/profile/{item.Id}";
                     Log.Information("[Avatar.DialogService] 加载角色 {Name} 头像，Session URL: {Url}", item.Name, sessionUrl);
                     
-                    var response = await _httpClient.GetStringAsync(sessionUrl);
+                    var response = await _httpClient.GetStringAsync(sessionUrl, avatarLoadCts.Token);
                     dynamic data = Newtonsoft.Json.JsonConvert.DeserializeObject(response);
                     
                     string textureProperty = null;
@@ -630,7 +632,7 @@ public class DialogService : IDialogService
                         if (!string.IsNullOrEmpty(skinUrl))
                         {
                             Log.Debug("[Avatar.DialogService] 角色 {Name} 皮肤 URL: {SkinUrl}", item.Name, skinUrl);
-                            var skinBytes = await _httpClient.GetByteArrayAsync(skinUrl);
+                            var skinBytes = await _httpClient.GetByteArrayAsync(skinUrl, avatarLoadCts.Token);
                             
                             _uiDispatcher.EnqueueAsync(async () =>
                             {
@@ -646,6 +648,11 @@ public class DialogService : IDialogService
                             }).Observe("DialogService.LoadProfileAvatar");
                         }
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    Log.Debug("[Avatar.DialogService] 头像加载任务已取消");
+                    break;
                 }
                 catch (Exception ex)
                 {
@@ -677,6 +684,7 @@ public class DialogService : IDialogService
             Content = listView,
             Style = Application.Current.Resources["DefaultContentDialogStyle"] as Style
         };
+        dialog.Closed += (_, _) => avatarLoadCts.Cancel();
 
         var result = await ShowSafeAsync(dialog);
         if (result == ContentDialogResult.Primary)

--- a/XianYuLauncher/Views/CharacterManagementPage.xaml.cs
+++ b/XianYuLauncher/Views/CharacterManagementPage.xaml.cs
@@ -412,10 +412,8 @@ namespace XianYuLauncher.Views
                 
                 Log.Information("[Avatar.CharacterManagementPage] 外置登录 Session URL: {Url}", sessionUrl);
 
-                // 2. 发送请求获取profile.properties
-                var httpClient = new HttpClient();
-                httpClient.DefaultRequestHeaders.Add("User-Agent", XianYuLauncher.Core.Helpers.VersionHelper.GetUserAgent());
-                var response = await httpClient.GetAsync(sessionUrl);
+                // 2. 发送请求获取profile.properties（复用页面 _httpClient，避免连接泄漏）
+                using var response = await _httpClient.GetAsync(sessionUrl);
                 if (!response.IsSuccessStatusCode)
                 {
                     Log.Warning("[Avatar.CharacterManagementPage] 外置登录 Session API 失败，URL: {Url}, 状态码: {StatusCode}", sessionUrl, response.StatusCode);

--- a/XianYuLauncher/Views/CharacterPage.xaml.cs
+++ b/XianYuLauncher/Views/CharacterPage.xaml.cs
@@ -1714,7 +1714,7 @@ namespace XianYuLauncher.Views
                 if (string.IsNullOrEmpty(authServer))
                 {
                     Log.Warning("[Avatar.CharacterPage] 外置角色 AuthServer 为空，角色: {Name}", profile.Name);
-                    return new BitmapImage(new Uri("ms-appx:///Assets/DefaultAvatar.png"));
+                    return new BitmapImage(new Uri("ms-appx:///Assets/Icons/Avatars/Steve.png"));
                 }
                 // 确保认证服务器URL以/结尾
                 if (!authServer.EndsWith("/"))
@@ -1730,7 +1730,7 @@ namespace XianYuLauncher.Views
             catch (Exception ex)
             {
                 Log.Error(ex, "[Avatar.CharacterPage] 加载外置角色头像异常，角色: {Name}, AuthServer: {AuthServer}", profile.Name, profile.AuthServer ?? "(null)");
-                return new BitmapImage(new Uri("ms-appx:///Assets/DefaultAvatar.png"));
+                return new BitmapImage(new Uri("ms-appx:///Assets/Icons/Avatars/Steve.png"));
             }
         }
 

--- a/XianYuLauncher/Views/LaunchPage.xaml.cs
+++ b/XianYuLauncher/Views/LaunchPage.xaml.cs
@@ -506,6 +506,7 @@ public sealed partial class LaunchPage : Page
             else
             {
                 sessionServerUri = new Uri($"https://sessionserver.mojang.com/session/minecraft/profile/{ViewModel.SelectedProfile.Id}");
+                Log.Debug("[Avatar.LaunchPage] 后台刷新微软登录 Session URL: {Url}", sessionServerUri.ToString());
             }
             
             var bitmap = await GetAvatarFromMojangApiAsync(sessionServerUri);


### PR DESCRIPTION
## 变更说明

用户反馈外置登录档案头像加载不出，排查时发现日志完全无埋点（此前使用 Debug.WriteLine，仅调试器可见，不写入 log 文件）。

### 主要改动

1. **Serilog 埋点**：将 CharacterPage、CharacterManagementPage、LaunchPage、DialogService 中头像相关 Debug.WriteLine 替换为 Serilog，统一 `[Avatar.xxx]` 前缀，便于在 log 中搜索
2. **Bug 修复**：CharacterManagementPage 在 CurrentSkin.Url 为空时回退到 LoadAvatarFromNetworkAsync，此前仅请求 Mojang API，外置登录会失败；现外置登录使用 AuthServer 的 Session URL
3. **防御性处理**：AuthServer 为空时提前返回，避免异常

### 涉及文件
- `XianYuLauncher/Services/DialogService.cs`
- `XianYuLauncher/Views/CharacterManagementPage.xaml.cs`
- `XianYuLauncher/Views/CharacterPage.xaml.cs`
- `XianYuLauncher/Views/LaunchPage.xaml.cs`
