### PR TITLE
fix(tests): 消除测试警告并对齐 Java 运行时接口可空性

### DIFF
--- a/XianYuLauncher.Core/Contracts/Services/IJavaRuntimeService.cs
+++ b/XianYuLauncher.Core/Contracts/Services/IJavaRuntimeService.cs
@@ -25,9 +25,9 @@ public interface IJavaRuntimeService
     /// <summary>
     /// 验证 Java 路径是否有效
     /// </summary>
-    /// <param name="javaPath">Java 可执行文件路径</param>
+    /// <param name="javaPath">Java 可执行文件路径；为 null 或空时视为无效</param>
     /// <returns>如果路径有效则返回 true，否则返回 false</returns>
-    Task<bool> ValidateJavaPathAsync(string javaPath);
+    Task<bool> ValidateJavaPathAsync(string? javaPath);
 
     /// <summary>
     /// 获取指定路径的 Java 版本信息
@@ -39,8 +39,8 @@ public interface IJavaRuntimeService
     /// <summary>
     /// 解析 Java 版本号
     /// </summary>
-    /// <param name="versionString">版本字符串（如 "1.8.0_301" 或 "17.0.1"）</param>
+    /// <param name="versionString">版本字符串（如 "1.8.0_301" 或 "17.0.1"）；为 null 或空时解析失败</param>
     /// <param name="majorVersion">解析出的主版本号</param>
     /// <returns>如果解析成功则返回 true，否则返回 false</returns>
-    bool TryParseJavaVersion(string versionString, out int majorVersion);
+    bool TryParseJavaVersion(string? versionString, out int majorVersion);
 }

--- a/XianYuLauncher.Core/Services/Java/JavaRuntimeService.cs
+++ b/XianYuLauncher.Core/Services/Java/JavaRuntimeService.cs
@@ -182,7 +182,7 @@ public class JavaRuntimeService : IJavaRuntimeService
     /// <summary>
     /// 验证 Java 路径是否有效
     /// </summary>
-    public Task<bool> ValidateJavaPathAsync(string javaPath)
+    public Task<bool> ValidateJavaPathAsync(string? javaPath)
     {
         if (string.IsNullOrEmpty(javaPath))
         {
@@ -287,7 +287,7 @@ public class JavaRuntimeService : IJavaRuntimeService
     /// <summary>
     /// 解析 Java 版本号
     /// </summary>
-    public bool TryParseJavaVersion(string versionString, out int majorVersion)
+    public bool TryParseJavaVersion(string? versionString, out int majorVersion)
     {
         majorVersion = 0;
         

--- a/XianYuLauncher.Tests/LibraryManagerTests.cs
+++ b/XianYuLauncher.Tests/LibraryManagerTests.cs
@@ -19,7 +19,7 @@ namespace XianYuLauncher.Tests
             // Arrange
             var mockLocalSettings = new Mock<ILocalSettingsService>();
             mockLocalSettings.Setup(x => x.ReadSettingAsync<string>(It.IsAny<string>()))
-                .ReturnsAsync((string)null);
+                .ReturnsAsync((string?)null);
                 
             var downloadManager = new DownloadManager(new NullLogger<DownloadManager>(), mockLocalSettings.Object);
             var logger = new NullLogger<LibraryManager>();

--- a/XianYuLauncher.Tests/Services/JavaRuntimeServiceTests.cs
+++ b/XianYuLauncher.Tests/Services/JavaRuntimeServiceTests.cs
@@ -38,7 +38,6 @@ public class JavaRuntimeServiceTests
 
     [Theory]
     [InlineData("")]
-    [InlineData(null)]
     [InlineData("invalid")]
     [InlineData("abc.def")]
     public void TryParseJavaVersion_InvalidVersionString_ReturnsFalse(string versionString)
@@ -47,6 +46,15 @@ public class JavaRuntimeServiceTests
         var result = _service.TryParseJavaVersion(versionString, out int majorVersion);
 
         // Assert
+        Assert.False(result);
+        Assert.Equal(0, majorVersion);
+    }
+
+    [Fact]
+    public void TryParseJavaVersion_Null_ReturnsFalse()
+    {
+        var result = _service.TryParseJavaVersion(null, out int majorVersion);
+
         Assert.False(result);
         Assert.Equal(0, majorVersion);
     }
@@ -95,10 +103,7 @@ public class JavaRuntimeServiceTests
     [Fact]
     public async Task SelectBestJavaAsync_WithVersionSpecificPath_ReturnsSpecificPath()
     {
-        // Arrange
-        var specificPath = @"C:\Java\jdk-17\bin\java.exe";
-        
-        // Create a temporary file to simulate java.exe
+        // Arrange — create a temporary file to simulate java.exe
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
         var tempJavaPath = Path.Combine(tempDir, "java.exe");

--- a/XianYuLauncher.Tests/Services/ModLoaderInstallers/LegacyFabricInstallerTests.cs
+++ b/XianYuLauncher.Tests/Services/ModLoaderInstallers/LegacyFabricInstallerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -86,8 +85,8 @@ public class LegacyFabricInstallerTests
             "legacyfabric-1.8.9"
         }));
 
-        var loaderLibrary = Assert.Single(merged.Libraries!.Where(library => library.Name == "net.legacyfabric:intermediary:1.8.9"));
-        var baseLibrary = Assert.Single(merged.Libraries.Where(library => library.Name == "com.mojang:brigadier:1.0.18"));
+        var loaderLibrary = Assert.Single(merged.Libraries!, library => library.Name == "net.legacyfabric:intermediary:1.8.9");
+        var baseLibrary = Assert.Single(merged.Libraries!, library => library.Name == "com.mojang:brigadier:1.0.18");
 
         Assert.NotNull(loaderLibrary.Downloads?.Artifact);
         Assert.Equal(

--- a/XianYuLauncher.Tests/Services/ModLoaderInstallers/LiteLoaderInstallerTests.cs
+++ b/XianYuLauncher.Tests/Services/ModLoaderInstallers/LiteLoaderInstallerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -71,12 +70,12 @@ public class LiteLoaderInstallerTests
             argument => Assert.Equal("--tweakClass", argument),
             argument => Assert.Equal("com.mumfrey.liteloader.launch.LiteLoaderTweaker", argument));
 
-        var liteLoaderJar = Assert.Single(resolved.Libraries!.Where(library => library.Name == "com.mumfrey:liteloader:1.8.9"));
+        var liteLoaderJar = Assert.Single(resolved.Libraries!, library => library.Name == "com.mumfrey:liteloader:1.8.9");
         Assert.Equal(
             "https://libraries.minecraft.net/com/mumfrey/liteloader/1.8.9/liteloader-1.8.9.jar",
             liteLoaderJar.Downloads!.Artifact!.Url);
 
-        var helperLibrary = Assert.Single(resolved.Libraries.Where(library => library.Name == "com.example:helper:1.0.0"));
+        var helperLibrary = Assert.Single(resolved.Libraries!, library => library.Name == "com.example:helper:1.0.0");
         Assert.Equal(
             "https://repo.example.com/releases/com/example/helper/1.0.0/helper-1.0.0.jar",
             helperLibrary.Downloads!.Artifact!.Url);


### PR DESCRIPTION
## 摘要
- 消除 `XianYuLauncher.Tests` 编译/分析器警告（可空、xUnit1012/2031、未使用变量等）
- `IJavaRuntimeService.ValidateJavaPathAsync` / `TryParseJavaVersion` 参数改为 `string?`，与现有 `IsNullOrEmpty` 守卫一致，无运行时行为变化

## 验证
- `dotnet test XianYuLauncher.Tests/XianYuLauncher.Tests.csproj` 通过